### PR TITLE
Add game launch options to online-fix menu

### DIFF
--- a/data/gtk/preferences.blp
+++ b/data/gtk/preferences.blp
@@ -465,6 +465,16 @@ template $SOFLPreferences: Adw.PreferencesDialog {
       }
     }
 
+    Adw.PreferencesGroup online_fix_launch_group {
+      title: _("Launch Options");
+      description: _("Steam-style launch options with %command% placeholder");
+
+      Adw.EntryRow online_fix_launch_options_entry {
+        title: _("Launch Options");
+        tooltip-text: _("Example: /path/to/script %command% --additional-args");
+      }
+    }
+
     Adw.PreferencesGroup online_fix_patches_group {
       title: _("Manual Patches");
       description: _("Configure manual patches for specific games");

--- a/data/org.badkiko.sofl.gschema.xml.in
+++ b/data/org.badkiko.sofl.gschema.xml.in
@@ -181,6 +181,11 @@
       <summary>Arguments after command</summary>
       <description>Additional arguments to add after the launch command</description>
     </key>
+    <key name="online-fix-launch-options" type="s">
+      <default>""</default>
+      <summary>Custom launch options</summary>
+      <description>Steam-style launch options with %command% placeholder for custom launchers</description>
+    </key>
     <key name="online-fix-debug-mode" type="b">
       <default>false</default>
       <summary>Debug mode</summary>

--- a/sofl/onlinefix_game.py
+++ b/sofl/onlinefix_game.py
@@ -125,13 +125,15 @@ class OnlineFixGameData(GameData):
         # Build launch command
         args_before = shared.schema.get_string("online-fix-args-before")
         args_after = shared.schema.get_string("online-fix-args-after")
+        launch_options = shared.schema.get_string("online-fix-launch-options")
 
         cmd_argv = SteamLauncher.build_launch_command(
             proton_path,
             str(game_exec),
             steam_runtime_path,
             args_before,
-            args_after
+            args_after,
+            launch_options
         )
 
         # Launch game

--- a/sofl/preferences.py
+++ b/sofl/preferences.py
@@ -128,6 +128,8 @@ class SOFLPreferences(Adw.PreferencesDialog):
     online_fix_auto_patch_switch: Adw.SwitchRow = Gtk.Template.Child()
     online_fix_dll_override_entry: Adw.EntryRow = Gtk.Template.Child()
     online_fix_dll_group: Adw.PreferencesGroup = Gtk.Template.Child()
+    online_fix_launch_options_entry: Adw.EntryRow = Gtk.Template.Child()
+    online_fix_launch_group: Adw.PreferencesGroup = Gtk.Template.Child()
     online_fix_patches_group: Adw.PreferencesGroup = Gtk.Template.Child()
     online_fix_steam_appid_switch: Adw.SwitchRow = Gtk.Template.Child()
     online_fix_patch_steam_fix_64: Adw.SwitchRow = Gtk.Template.Child()
@@ -572,6 +574,14 @@ class SOFLPreferences(Adw.PreferencesDialog):
             "changed", self.on_dll_overrides_changed
         )
 
+        # Setup Launch Options
+        self.online_fix_launch_options_entry.set_text(
+            shared.schema.get_string("online-fix-launch-options")
+        )
+        self.online_fix_launch_options_entry.connect(
+            "changed", self.on_launch_options_changed
+        )
+
         # Setup manual patches
         shared.schema.bind(
             "online-fix-steam-appid-patch",
@@ -671,6 +681,10 @@ class SOFLPreferences(Adw.PreferencesDialog):
     def on_dll_overrides_changed(self, entry: Adw.EntryRow) -> None:
         """Handler for DLL overrides change"""
         shared.schema.set_string("online-fix-dll-overrides", entry.get_text())
+
+    def on_launch_options_changed(self, entry: Adw.EntryRow) -> None:
+        """Handler for launch options change"""
+        shared.schema.set_string("online-fix-launch-options", entry.get_text())
 
     def online_fix_path_browse_handler(self, *_args):
         """Choose directory for Online-Fix games installation"""

--- a/sofl/utils/steam_launcher.py
+++ b/sofl/utils/steam_launcher.py
@@ -179,29 +179,47 @@ class SteamLauncher:
         steam_runtime_path: Optional[str] = None,
         args_before: Optional[str] = None,
         args_after: Optional[str] = None,
+        launch_options: Optional[str] = None,
     ) -> List[str]:
         """Builds game launch command"""
-        cmd_argv = [proton_path, "run", game_exec]
+        # Build the base command (this becomes %command%)
+        base_cmd = [proton_path, "run", game_exec]
 
         if steam_runtime_path:
-            cmd_argv.insert(0, steam_runtime_path)
+            base_cmd.insert(0, steam_runtime_path)
 
-        # Safely add arguments
+        # Safely add online-fix arguments to base command
         if args_before:
             try:
                 args_before_list = shlex.split(args_before)
-                cmd_argv = args_before_list + cmd_argv
+                base_cmd = args_before_list + base_cmd
             except ValueError as e:
                 logging.warning(f"[SOFL] Failed to parse args_before '{args_before}': {e}")
 
         if args_after:
             try:
                 args_after_list = shlex.split(args_after)
-                cmd_argv.extend(args_after_list)
+                base_cmd.extend(args_after_list)
             except ValueError as e:
                 logging.warning(f"[SOFL] Failed to parse args_after '{args_after}': {e}")
 
-        return cmd_argv
+        # Handle custom launch options with %command% replacement
+        if launch_options and launch_options.strip():
+            try:
+                # Replace %command% with the base command
+                base_cmd_str = " ".join(shlex.quote(arg) for arg in base_cmd)
+                final_command_str = launch_options.replace("%command%", base_cmd_str)
+                
+                # Parse the final command back into argv
+                cmd_argv = shlex.split(final_command_str)
+                logging.info(f"[SOFL] Using custom launch options: {launch_options}")
+                logging.info(f"[SOFL] Final command: {final_command_str}")
+                return cmd_argv
+            except ValueError as e:
+                logging.warning(f"[SOFL] Failed to parse launch_options '{launch_options}': {e}")
+                logging.info(f"[SOFL] Falling back to default command")
+
+        return base_cmd
 
     @staticmethod
     def launch_game(cmd_argv: List[str], env: Dict[str, str], game_dir: Path, in_flatpak: bool = False) -> None:


### PR DESCRIPTION
Add a "Launch Options" field to the Online-Fix menu to allow custom commands with `%command%` replacement, preserving online-fix arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-42e614fa-d6ac-4ca2-b486-e1d8fc75097b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42e614fa-d6ac-4ca2-b486-e1d8fc75097b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

