### PR TITLE
Add game launch options to online-fix menu

### DIFF
--- a/data/gtk/preferences.blp
+++ b/data/gtk/preferences.blp
@@ -465,6 +465,16 @@ template $SOFLPreferences: Adw.PreferencesDialog {
       }
     }
 
+    Adw.PreferencesGroup online_fix_launch_options_group {
+      title: _("Launch Options");
+      description: _("Configure custom launch options for games");
+
+      Adw.EntryRow online_fix_launch_options_entry {
+        title: _("Launch Options");
+        tooltip-text: _("Format: /path/to/script %command% or additional arguments. Use %command% where the game command should be placed.");
+      }
+    }
+
     Adw.PreferencesGroup online_fix_patches_group {
       title: _("Manual Patches");
       description: _("Configure manual patches for specific games");

--- a/data/org.badkiko.sofl.gschema.xml.in
+++ b/data/org.badkiko.sofl.gschema.xml.in
@@ -136,6 +136,11 @@
       <summary>DLL overrides</summary>
       <description>DLL overrides for Wine/Proton in format: dll1=n,b;dll2=n,b</description>
     </key>
+    <key name="online-fix-launch-options" type="s">
+      <default>""</default>
+      <summary>Launch options</summary>
+      <description>Custom launch options to be included with the game launch command (e.g. /path/to/script %command%)</description>
+    </key>
     <key name="online-fix-steam-api-patch" type="b">
       <default>true</default>
       <summary>Steam API patch</summary>

--- a/sofl/onlinefix_game.py
+++ b/sofl/onlinefix_game.py
@@ -125,13 +125,15 @@ class OnlineFixGameData(GameData):
         # Build launch command
         args_before = shared.schema.get_string("online-fix-args-before")
         args_after = shared.schema.get_string("online-fix-args-after")
+        launch_options = shared.schema.get_string("online-fix-launch-options")
 
         cmd_argv = SteamLauncher.build_launch_command(
             proton_path,
             str(game_exec),
             steam_runtime_path,
             args_before,
-            args_after
+            args_after,
+            launch_options
         )
 
         # Launch game

--- a/sofl/preferences.py
+++ b/sofl/preferences.py
@@ -128,6 +128,8 @@ class SOFLPreferences(Adw.PreferencesDialog):
     online_fix_auto_patch_switch: Adw.SwitchRow = Gtk.Template.Child()
     online_fix_dll_override_entry: Adw.EntryRow = Gtk.Template.Child()
     online_fix_dll_group: Adw.PreferencesGroup = Gtk.Template.Child()
+    online_fix_launch_options_entry: Adw.EntryRow = Gtk.Template.Child()
+    online_fix_launch_options_group: Adw.PreferencesGroup = Gtk.Template.Child()
     online_fix_patches_group: Adw.PreferencesGroup = Gtk.Template.Child()
     online_fix_steam_appid_switch: Adw.SwitchRow = Gtk.Template.Child()
     online_fix_patch_steam_fix_64: Adw.SwitchRow = Gtk.Template.Child()
@@ -572,6 +574,14 @@ class SOFLPreferences(Adw.PreferencesDialog):
             "changed", self.on_dll_overrides_changed
         )
 
+        # Setup Launch options
+        self.online_fix_launch_options_entry.set_text(
+            shared.schema.get_string("online-fix-launch-options")
+        )
+        self.online_fix_launch_options_entry.connect(
+            "changed", self.on_launch_options_changed
+        )
+
         # Setup manual patches
         shared.schema.bind(
             "online-fix-steam-appid-patch",
@@ -671,6 +681,10 @@ class SOFLPreferences(Adw.PreferencesDialog):
     def on_dll_overrides_changed(self, entry: Adw.EntryRow) -> None:
         """Handler for DLL overrides change"""
         shared.schema.set_string("online-fix-dll-overrides", entry.get_text())
+
+    def on_launch_options_changed(self, entry: Adw.EntryRow) -> None:
+        """Handler for launch options change"""
+        shared.schema.set_string("online-fix-launch-options", entry.get_text())
 
     def online_fix_path_browse_handler(self, *_args):
         """Choose directory for Online-Fix games installation"""

--- a/sofl/utils/steam_launcher.py
+++ b/sofl/utils/steam_launcher.py
@@ -179,14 +179,40 @@ class SteamLauncher:
         steam_runtime_path: Optional[str] = None,
         args_before: Optional[str] = None,
         args_after: Optional[str] = None,
+        launch_options: Optional[str] = None,
     ) -> List[str]:
         """Builds game launch command"""
-        cmd_argv = [proton_path, "run", game_exec]
-
+        # Build the base command
+        base_cmd = [proton_path, "run", game_exec]
+        
         if steam_runtime_path:
-            cmd_argv.insert(0, steam_runtime_path)
+            base_cmd.insert(0, steam_runtime_path)
+        
+        # Apply launch options if provided
+        if launch_options and "%command%" in launch_options:
+            try:
+                # Parse the launch options
+                launch_parts = shlex.split(launch_options)
+                
+                # Find where %command% is and replace it with the base command
+                cmd_argv = []
+                for part in launch_parts:
+                    if part == "%command%":
+                        cmd_argv.extend(base_cmd)
+                    else:
+                        cmd_argv.append(part)
+                
+                # If %command% wasn't found, append base command at the end
+                if "%command%" not in launch_parts:
+                    cmd_argv.extend(base_cmd)
+                    
+            except ValueError as e:
+                logging.warning(f"[SOFL] Failed to parse launch_options '{launch_options}': {e}")
+                cmd_argv = base_cmd
+        else:
+            cmd_argv = base_cmd
 
-        # Safely add arguments
+        # Safely add arguments before (these are required online-fix args)
         if args_before:
             try:
                 args_before_list = shlex.split(args_before)
@@ -194,6 +220,7 @@ class SteamLauncher:
             except ValueError as e:
                 logging.warning(f"[SOFL] Failed to parse args_before '{args_before}': {e}")
 
+        # Safely add arguments after (these are required online-fix args)
         if args_after:
             try:
                 args_after_list = shlex.split(args_after)


### PR DESCRIPTION
Add a "Launch Options" field to the Online-Fix menu, allowing Steam-like custom commands while preserving online-fix arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d4306cd-a670-4b2e-819d-e130c2223412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d4306cd-a670-4b2e-819d-e130c2223412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

